### PR TITLE
Handle subprocess errors during AI analysis

### DIFF
--- a/routes/analyze_routes.py
+++ b/routes/analyze_routes.py
@@ -140,7 +140,14 @@ def _run_ai_analysis(img_path: Path, provider: str) -> dict:
         raise ValueError(f"Unknown provider: {provider}")
 
     logger.info("[DEBUG] Subprocess cmd: %s", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    except subprocess.TimeoutExpired as e:
+        logger.error("AI analysis timed out: %s", e)
+        raise RuntimeError("AI analysis timed out") from e
+    except FileNotFoundError as e:
+        logger.error("Analysis script not found: %s", e)
+        raise RuntimeError("Analysis script not found") from e
 
     if result.returncode != 0:
         msg = (result.stderr or "Unknown error").strip()

--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -215,7 +215,14 @@ def _run_ai_analysis(img_path: Path, provider: str) -> dict:
         raise ValueError(f"Unknown provider: {provider}")
 
     logger.info("[DEBUG] Subprocess cmd: %s", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    except subprocess.TimeoutExpired as e:
+        logger.error("AI analysis timed out: %s", e)
+        raise RuntimeError("AI analysis timed out") from e
+    except FileNotFoundError as e:
+        logger.error("Analysis script not found: %s", e)
+        raise RuntimeError("Analysis script not found") from e
 
     if result.returncode != 0:
         msg = (result.stderr or "Unknown error").strip()

--- a/tests/test_run_ai_analysis_exceptions.py
+++ b/tests/test_run_ai_analysis_exceptions.py
@@ -1,0 +1,21 @@
+import subprocess
+from pathlib import Path
+import pytest
+
+from routes.artwork_routes import _run_ai_analysis
+
+
+def test_run_ai_analysis_timeout(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    with pytest.raises(RuntimeError, match='timed out'):
+        _run_ai_analysis(Path('img.jpg'), 'openai')
+
+
+def test_run_ai_analysis_missing_script(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        raise FileNotFoundError('no such file')
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    with pytest.raises(RuntimeError, match='not found'):
+        _run_ai_analysis(Path('img.jpg'), 'openai')


### PR DESCRIPTION
## Summary
- add explicit handling for missing scripts and timeouts when running AI analysis subprocesses
- cover timeout and missing script scenarios with dedicated unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dd597aa1c832eb9f4a52a776fb660